### PR TITLE
[Feat] Apple Login, FirebaseAuth Setting

### DIFF
--- a/LoveCrane/LoveCrane.xcodeproj/project.pbxproj
+++ b/LoveCrane/LoveCrane.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		865772D12A6531D400D40B59 /* AppleLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D02A6531D400D40B59 /* AppleLoginButton.swift */; };
+		865772D32A65335D00D40B59 /* AppleLoginResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D22A65335D00D40B59 /* AppleLoginResult.swift */; };
+		865772D62A65344500D40B59 /* AppleLoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D52A65344500D40B59 /* AppleLoginHelper.swift */; };
+		865772D82A65367D00D40B59 /* TopViewControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D72A65367D00D40B59 /* TopViewControllerManager.swift */; };
 		C70A1D9C2A631EB000BB9659 /* LoveCraneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70A1D9B2A631EB000BB9659 /* LoveCraneApp.swift */; };
 		C70A1DA02A631EB100BB9659 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70A1D9F2A631EB100BB9659 /* Assets.xcassets */; };
 		C70A1DA32A631EB100BB9659 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70A1DA22A631EB100BB9659 /* Preview Assets.xcassets */; };
@@ -39,6 +43,10 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		865772D02A6531D400D40B59 /* AppleLoginButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginButton.swift; sourceTree = "<group>"; };
+		865772D22A65335D00D40B59 /* AppleLoginResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginResult.swift; sourceTree = "<group>"; };
+		865772D52A65344500D40B59 /* AppleLoginHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginHelper.swift; sourceTree = "<group>"; };
+		865772D72A65367D00D40B59 /* TopViewControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewControllerManager.swift; sourceTree = "<group>"; };
 		C70A1D982A631EB000BB9659 /* LoveCrane.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LoveCrane.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70A1D9B2A631EB000BB9659 /* LoveCraneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoveCraneApp.swift; sourceTree = "<group>"; };
 		C70A1D9F2A631EB100BB9659 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -82,6 +90,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		865772D42A65342A00D40B59 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				865772D52A65344500D40B59 /* AppleLoginHelper.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		C70A1D8F2A631EB000BB9659 = {
 			isa = PBXGroup;
 			children = (
@@ -136,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				C70A1DAD2A6323F700BB9659 /* User.swift */,
+				865772D22A65335D00D40B59 /* AppleLoginResult.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -151,7 +168,9 @@
 		C70A1DB02A6323F700BB9659 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				865772D42A65342A00D40B59 /* Helpers */,
 				C70A1DB12A6323F700BB9659 /* SampleManager.swift */,
+				865772D72A65367D00D40B59 /* TopViewControllerManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -292,6 +311,7 @@
 		C70A1DCF2A6323F700BB9659 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				865772D02A6531D400D40B59 /* AppleLoginButton.swift */,
 				C70A1DD02A6323F700BB9659 /* LoginView.swift */,
 			);
 			path = Login;
@@ -388,8 +408,10 @@
 				C70A1DD22A6323F700BB9659 /* FirebaseNetwork.swift in Sources */,
 				C70A1DD62A6323F700BB9659 /* DetailViewModel.swift in Sources */,
 				C70A1DD32A6323F700BB9659 /* SampleManager.swift in Sources */,
+				865772D82A65367D00D40B59 /* TopViewControllerManager.swift in Sources */,
 				C70A1DD72A6323F700BB9659 /* WriteViewModel.swift in Sources */,
 				C70A1D9C2A631EB000BB9659 /* LoveCraneApp.swift in Sources */,
+				865772D62A65344500D40B59 /* AppleLoginHelper.swift in Sources */,
 				C70A1DDA2A6323F700BB9659 /* LoginViewModel.swift in Sources */,
 				C70A1DD82A6323F700BB9659 /* SettingViewModel.swift in Sources */,
 				C70A1DE22A6323F700BB9659 /* LoginView.swift in Sources */,
@@ -398,7 +420,9 @@
 				C70A1DDC2A6323F700BB9659 /* DetailView.swift in Sources */,
 				C7A1B6812A6522FC00040C1C /* AppDelegate.swift in Sources */,
 				C70A1DDE2A6323F700BB9659 /* ReciveHistoryView.swift in Sources */,
+				865772D32A65335D00D40B59 /* AppleLoginResult.swift in Sources */,
 				C70A1DD92A6323F700BB9659 /* MainViewModel.swift in Sources */,
+				865772D12A6531D400D40B59 /* AppleLoginButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LoveCrane/LoveCrane.xcodeproj/project.pbxproj
+++ b/LoveCrane/LoveCrane.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		865772D32A65335D00D40B59 /* AppleLoginResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D22A65335D00D40B59 /* AppleLoginResult.swift */; };
 		865772D62A65344500D40B59 /* AppleLoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D52A65344500D40B59 /* AppleLoginHelper.swift */; };
 		865772D82A65367D00D40B59 /* TopViewControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D72A65367D00D40B59 /* TopViewControllerManager.swift */; };
+		865772DA2A65535D00D40B59 /* AuthDataResultModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772D92A65535D00D40B59 /* AuthDataResultModel.swift */; };
+		865772DC2A65548800D40B59 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772DB2A65548800D40B59 /* AuthenticationManager.swift */; };
+		865772DE2A6556E600D40B59 /* AuthErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865772DD2A6556E600D40B59 /* AuthErrors.swift */; };
 		C70A1D9C2A631EB000BB9659 /* LoveCraneApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70A1D9B2A631EB000BB9659 /* LoveCraneApp.swift */; };
 		C70A1DA02A631EB100BB9659 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70A1D9F2A631EB100BB9659 /* Assets.xcassets */; };
 		C70A1DA32A631EB100BB9659 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C70A1DA22A631EB100BB9659 /* Preview Assets.xcassets */; };
@@ -47,6 +50,9 @@
 		865772D22A65335D00D40B59 /* AppleLoginResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginResult.swift; sourceTree = "<group>"; };
 		865772D52A65344500D40B59 /* AppleLoginHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginHelper.swift; sourceTree = "<group>"; };
 		865772D72A65367D00D40B59 /* TopViewControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewControllerManager.swift; sourceTree = "<group>"; };
+		865772D92A65535D00D40B59 /* AuthDataResultModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthDataResultModel.swift; sourceTree = "<group>"; };
+		865772DB2A65548800D40B59 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
+		865772DD2A6556E600D40B59 /* AuthErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthErrors.swift; sourceTree = "<group>"; };
 		C70A1D982A631EB000BB9659 /* LoveCrane.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LoveCrane.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C70A1D9B2A631EB000BB9659 /* LoveCraneApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoveCraneApp.swift; sourceTree = "<group>"; };
 		C70A1D9F2A631EB100BB9659 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -144,6 +150,7 @@
 			isa = PBXGroup;
 			children = (
 				C70A1DAA2A6323D500BB9659 /* Font.swift */,
+				865772DD2A6556E600D40B59 /* AuthErrors.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -153,6 +160,7 @@
 			children = (
 				C70A1DAD2A6323F700BB9659 /* User.swift */,
 				865772D22A65335D00D40B59 /* AppleLoginResult.swift */,
+				865772D92A65535D00D40B59 /* AuthDataResultModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -171,6 +179,7 @@
 				865772D42A65342A00D40B59 /* Helpers */,
 				C70A1DB12A6323F700BB9659 /* SampleManager.swift */,
 				865772D72A65367D00D40B59 /* TopViewControllerManager.swift */,
+				865772DB2A65548800D40B59 /* AuthenticationManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -410,10 +419,12 @@
 				C70A1DD32A6323F700BB9659 /* SampleManager.swift in Sources */,
 				865772D82A65367D00D40B59 /* TopViewControllerManager.swift in Sources */,
 				C70A1DD72A6323F700BB9659 /* WriteViewModel.swift in Sources */,
+				865772DC2A65548800D40B59 /* AuthenticationManager.swift in Sources */,
 				C70A1D9C2A631EB000BB9659 /* LoveCraneApp.swift in Sources */,
 				865772D62A65344500D40B59 /* AppleLoginHelper.swift in Sources */,
 				C70A1DDA2A6323F700BB9659 /* LoginViewModel.swift in Sources */,
 				C70A1DD82A6323F700BB9659 /* SettingViewModel.swift in Sources */,
+				865772DA2A65535D00D40B59 /* AuthDataResultModel.swift in Sources */,
 				C70A1DE22A6323F700BB9659 /* LoginView.swift in Sources */,
 				C70A1DAB2A6323D500BB9659 /* Font.swift in Sources */,
 				C70A1DD52A6323F700BB9659 /* WirteHistoryViewModel.swift in Sources */,
@@ -422,6 +433,7 @@
 				C70A1DDE2A6323F700BB9659 /* ReciveHistoryView.swift in Sources */,
 				865772D32A65335D00D40B59 /* AppleLoginResult.swift in Sources */,
 				C70A1DD92A6323F700BB9659 /* MainViewModel.swift in Sources */,
+				865772DE2A6556E600D40B59 /* AuthErrors.swift in Sources */,
 				865772D12A6531D400D40B59 /* AppleLoginButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LoveCrane/LoveCrane/Common/AuthErrors.swift
+++ b/LoveCrane/LoveCrane/Common/AuthErrors.swift
@@ -1,0 +1,14 @@
+//
+//  AuthErrors.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import Foundation
+
+enum AuthErrors: Error {
+    case failedToGetAuthenticatedCurrentUser
+    case failedToGetTopViewController
+    case failedToMakeAppleIDCredential
+}

--- a/LoveCrane/LoveCrane/Manager/AuthenticationManager.swift
+++ b/LoveCrane/LoveCrane/Manager/AuthenticationManager.swift
@@ -1,0 +1,49 @@
+//
+//  AuthenticationManager.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import Foundation
+import FirebaseAuth
+
+final class AuthenticationManager {
+    
+    // 앱 전반에서 인증 관련 작업을 처리할 것이기 때문에 싱글톤 패턴을 적용.(일관성 유지 및 효율성을 위해)
+    static let shared = AuthenticationManager()
+    private init() { }
+    
+    // MARK: credential을 통한 파이어베이스 로그인
+    func signIn(credential: AuthCredential) async throws -> AuthDataResultModel{
+        let authDataResult = try await Auth.auth().signIn(with: credential)
+        return AuthDataResultModel(user: authDataResult.user)
+    }
+    // MARK: 현재 로그인된 유저의 정보를 가져오는 메서드 (로컬)
+    func getAuthenticatedUser() throws -> AuthDataResultModel {
+        guard let user = Auth.auth().currentUser else {
+            throw AuthErrors.failedToGetAuthenticatedCurrentUser
+        }
+        return AuthDataResultModel(user: user)
+    }
+    // MARK: 로그아웃
+    func signOut() throws {
+        try Auth.auth().signOut()
+    }
+    // MARK: 서버에서 유저를 삭제 (회원 탈퇴)
+    func deleteUser() async throws {
+        guard let user = Auth.auth().currentUser else {
+            throw AuthErrors.failedToGetAuthenticatedCurrentUser
+        }
+        try await user.delete()
+    }
+}
+
+extension AuthenticationManager {
+    // MARK: 애플 로그인 
+    @discardableResult
+    func signInWithApple(tokens: AppleLoginResult) async throws -> AuthDataResultModel {
+        let credential = OAuthProvider.credential(withProviderID: AuthProviderOption.apple.rawValue, idToken: tokens.token, rawNonce: tokens.nonce)
+        return try await signIn(credential: credential)
+    }
+}

--- a/LoveCrane/LoveCrane/Manager/Helpers/AppleLoginHelper.swift
+++ b/LoveCrane/LoveCrane/Manager/Helpers/AppleLoginHelper.swift
@@ -20,7 +20,7 @@ final class AppleLoginHelper: NSObject {
     func startSignInWithAppleFlow(completion: @escaping (Result<AppleLoginResult, Error>) -> Void) {
         
         guard let topVC = TopViewControllerManager.shared.topViewController() else {
-            completion(.failure(URLError(.badURL)))
+            completion(.failure(AuthErrors.failedToGetTopViewController))
             return
         }
         
@@ -81,7 +81,7 @@ extension AppleLoginHelper: ASAuthorizationControllerDelegate {
             let appleIDToken = appleIDCredential.identityToken,
             let idTokenString = String(data: appleIDToken, encoding: .utf8),
             let nonce = currentNonce else {
-            completionHandler?(.failure(URLError(.badServerResponse)))
+            completionHandler?(.failure(AuthErrors.failedToMakeAppleIDCredential))
             return
         }
         
@@ -93,7 +93,7 @@ extension AppleLoginHelper: ASAuthorizationControllerDelegate {
     }
 
   func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-    print("애플 로그인 에러 발생: \(error)")
+      print("애플 로그인 에러 발생: \(error.localizedDescription)")
   }
 }
 

--- a/LoveCrane/LoveCrane/Manager/Helpers/AppleLoginHelper.swift
+++ b/LoveCrane/LoveCrane/Manager/Helpers/AppleLoginHelper.swift
@@ -1,0 +1,108 @@
+//
+//  AppleLoginHelper.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import SwiftUI
+import AuthenticationServices
+import CryptoKit
+
+@MainActor
+final class AppleLoginHelper: NSObject {
+    
+    private var currentNonce: String?
+    
+    private var completionHandler: ((Result<AppleLoginResult, Error>) -> Void)? = nil
+    
+    // MARK: 애플 로그인 플로우 시작
+    func startSignInWithAppleFlow(completion: @escaping (Result<AppleLoginResult, Error>) -> Void) {
+        
+        guard let topVC = TopViewControllerManager.shared.topViewController() else {
+            completion(.failure(URLError(.badURL)))
+            return
+        }
+        
+      let nonce = randomNonceString()
+      currentNonce = nonce
+        
+      completionHandler = completion
+        
+      let appleIDProvider = ASAuthorizationAppleIDProvider()
+      let request = appleIDProvider.createRequest()
+      request.requestedScopes = [.fullName, .email]
+      request.nonce = sha256(nonce)
+
+      let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+      authorizationController.delegate = self
+      authorizationController.presentationContextProvider = topVC
+      authorizationController.performRequests()
+    }
+    
+    // MARK: Nonce 난수 문자열
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        var randomBytes = [UInt8](repeating: 0, count: length)
+        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if errorCode != errSecSuccess {
+            preconditionFailure(
+                "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
+        }
+        let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        
+        let nonce = randomBytes.map { byte in
+            charset[Int(byte) % charset.count]
+        }
+        return String(nonce)
+    }
+
+    // MARK: nonce 해시화
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+}
+
+// MARK: ASAuthorizationControllerDelegate
+extension AppleLoginHelper: ASAuthorizationControllerDelegate {
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        
+        guard
+            let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let appleIDToken = appleIDCredential.identityToken,
+            let idTokenString = String(data: appleIDToken, encoding: .utf8),
+            let nonce = currentNonce else {
+            completionHandler?(.failure(URLError(.badServerResponse)))
+            return
+        }
+        
+        let userName = appleIDCredential.fullName?.givenName
+        let email = appleIDCredential.email
+        
+        let tokens = AppleLoginResult(token: idTokenString, nonce: nonce, userName: userName, email: email)
+        completionHandler?(.success(tokens))
+    }
+
+  func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+    print("애플 로그인 에러 발생: \(error)")
+  }
+}
+
+//MARK: ASAuthorizationControllerPresentationContextProviding
+extension UIViewController: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let window = self.view.window else {
+            preconditionFailure("Unable to access view's window.")
+        }
+        return window
+    }
+}

--- a/LoveCrane/LoveCrane/Manager/TopViewControllerManager.swift
+++ b/LoveCrane/LoveCrane/Manager/TopViewControllerManager.swift
@@ -1,0 +1,44 @@
+//
+//  TopViewControllerManager.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import UIKit
+
+// MARK: authorizationController의 delegate와 contextProvider위한 최상단 뷰 컨트롤러를 리턴하는 클래스
+@MainActor
+final class TopViewControllerManager {
+    
+    static let shared = TopViewControllerManager()
+    private init() { }
+    
+    func topViewController(controller: UIViewController? = nil) -> UIViewController? {
+        guard let scene = UIApplication.shared.connectedScenes.first,
+              let windowSceneDelegate = scene.delegate as? UIWindowSceneDelegate,
+              let window = windowSceneDelegate.window else {
+            return nil
+        }
+        
+        return topViewController(for: window?.rootViewController)
+    }
+    
+    private func topViewController(for controller: UIViewController?) -> UIViewController? {
+        if let navigationController = controller as? UINavigationController {
+            return topViewController(for: navigationController.visibleViewController)
+        }
+        
+        if let tabController = controller as? UITabBarController {
+            if let selected = tabController.selectedViewController {
+                return topViewController(for: selected)
+            }
+        }
+        
+        if let presented = controller?.presentedViewController {
+            return topViewController(for: presented)
+        }
+        
+        return controller
+    }
+}

--- a/LoveCrane/LoveCrane/Model/AppleLoginResult.swift
+++ b/LoveCrane/LoveCrane/Model/AppleLoginResult.swift
@@ -1,0 +1,16 @@
+//
+//  AppleLoginResult.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import Foundation
+
+//MARK: 애플 로그인 플로우 완료 시 반환값을 관리하기 위한 구조체입니다.(OAuthProvider를 통해 credential을 만들 데이터)
+struct AppleLoginResult {
+    let token: String
+    let nonce: String
+    let userName: String?
+    let email: String?
+}

--- a/LoveCrane/LoveCrane/Model/AuthDataResultModel.swift
+++ b/LoveCrane/LoveCrane/Model/AuthDataResultModel.swift
@@ -1,0 +1,28 @@
+//
+//  AuthDataResultModel.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import Foundation
+import FirebaseAuth
+
+// MARK: 파이어베이스 로그인 관련 유저의 *uid를 포함한 정보를 포함하는 구조체입니다.
+
+struct AuthDataResultModel {
+    let uid: String
+    let email: String?
+    let photoUrl: String?
+    
+    init(user: User) {
+        self.uid = user.uid
+        self.email = user.email
+        self.photoUrl = user.photoURL?.absoluteString
+    }
+}
+
+// MARK: provider 옵션 값을 관리하는 열거형입니다.(ex. 애플, 구글 등)
+enum AuthProviderOption: String {
+    case apple = "apple.com"
+}

--- a/LoveCrane/LoveCrane/View/Login/AppleLoginButton.swift
+++ b/LoveCrane/LoveCrane/View/Login/AppleLoginButton.swift
@@ -1,0 +1,25 @@
+//
+//  AppleLoginButtonRepresentable.swift
+//  LoveCrane
+//
+//  Created by Toughie on 2023/07/17.
+//
+
+import SwiftUI
+import AuthenticationServices
+import CryptoKit
+
+// MARK: UIViewRepresentable을 활용한 애플 로그인 버튼입니다.
+// 초기화 시 버튼 타입과 스타일을 정해줄 수 있습니다.
+struct SignInWithAppleButtonViewRepresentable: UIViewRepresentable {
+    
+    let buttonType: ASAuthorizationAppleIDButton.ButtonType
+    let buttonStyle: ASAuthorizationAppleIDButton.Style
+    
+    func makeUIView(context: Context) -> ASAuthorizationAppleIDButton {
+        ASAuthorizationAppleIDButton(authorizationButtonType: buttonType, authorizationButtonStyle: buttonStyle)
+    }
+    
+    func updateUIView(_ uiView: ASAuthorizationAppleIDButton, context: Context) {
+    }
+}


### PR DESCRIPTION
##  PR 😊

🥚 작업한 브랜치 : #5 

## ✏️ 작업한 내용
- ### 애플 로그인 세팅:
  AppleLoginResult, AppleLoginHelper, TopViewControllerManager를 추가했습니다.
- ### 파이어베이스 로그인 세팅:
    파이어베이스 인증을 위한 AuthDataResultModel, AuthenticanManager, 그리고 관련 에러 처리를 위한 AuthErrors를 추가했습니다.


## 📷 스크린샷

## 📮 관련 이슈

