### PR TITLE
[Fix] WriteView에서 Keyboard 떴을때 상단 이미지 + label 같이 떠오르기 버그 픽스

### DIFF
--- a/LovelyCrane/View/Login/NicknameView.swift
+++ b/LovelyCrane/View/Login/NicknameView.swift
@@ -33,13 +33,13 @@ struct NicknameView: View {
 //                            .frame(width: 124, height: 48)
                         
                         Text("사용하실 닉네임을 알려주세요")
-                            .foregroundColor(.white)
+                            .foregroundColor(.primaryLabel)
                     }
 
                     VStack {
                         TextField("닉네임을 입력해주세요", text: $viewModel.nickname)
                             .focused($nicknameInFocus)
-                            .foregroundColor(.white)
+                            .foregroundColor(.primaryLabel)
                             .multilineTextAlignment(TextAlignment.center)
                             .padding()
                             .frame(maxWidth: .infinity)
@@ -48,7 +48,7 @@ struct NicknameView: View {
                                     Color.textFieldGray
                                     if viewModel.nickname.count == 0 {
                                         Text("닉네임을 입력해주세요")
-                                            .foregroundColor(Color.fontGray)
+                                            .foregroundColor(Color.tertiaryLabel)
                                     }
                                 }
                             )
@@ -58,7 +58,7 @@ struct NicknameView: View {
                             Image("exclamationMark")
                                 .opacity(viewModel.nickname.count > 8 ? 1 : 0)
                             Text("닉네임은 8자 이하로 입력해주세요")
-                                .foregroundColor(viewModel.nickname.count > 8 ? Color.defaultYellow : Color.fontGray)
+                                .foregroundColor(viewModel.nickname.count > 8 ? Color.defaultYellow : Color.tertiaryLabel)
                         }
                     }
                 }

--- a/LovelyCrane/View/Main/MainView.swift
+++ b/LovelyCrane/View/Main/MainView.swift
@@ -60,10 +60,10 @@ struct MainView: View {
     private func presentedBottle() -> some View {
         VStack {
             Text("to. \(partnerName)")
-                .foregroundColor(.secondary)
+                .foregroundColor(.secondaryLabel)
                 .padding(.top)
             Text("\(letterCount)")
-                .foregroundColor(.white)
+                .foregroundColor(.primaryLabel)
                 .font(.system(size: 50))
             spriteView()
             Spacer()
@@ -73,10 +73,10 @@ struct MainView: View {
     private func mainBottle() -> some View {
         VStack {
             Text("to. \(partnerName)")
-                .foregroundColor(.secondary)
+                .foregroundColor(.secondaryLabel)
                 .padding(.top)
             Text("\(letterCount)")
-                .foregroundColor(.white)
+                .foregroundColor(.primaryLabel)
                 .font(.system(size: 50))
             spriteView()
             Spacer()
@@ -122,7 +122,7 @@ struct MainView: View {
     //Todo: 랜덤하게 fill 컬러 추가해주고, 해당 컬러에 맞는 크레인 명을 color로 보내주어야 함
     private func bottomWriteButton() -> some View {
         RoundedRectangle(cornerRadius: 20)
-            .fill(Color.red)
+            .fill(Color.deepPink)
             .frame(width: CGSize.deviceWidth * 0.8)
             .offset(y: CGSize.deviceHeight * 0.08)
             .ignoresSafeArea()

--- a/LovelyCrane/View/Setting/SettingView2.swift
+++ b/LovelyCrane/View/Setting/SettingView2.swift
@@ -81,7 +81,7 @@ extension SettingView2 {
     private func makeCell(name: String) -> some View {
         VStack(alignment: .leading) {
             Text(name)
-                .foregroundColor(.white)
+                .foregroundColor(.primaryLabel)
                 .padding()
 //            Divider()
 //                .frame(height: 0.5)

--- a/LovelyCrane/View/WriteHistory/WriteHistoryView.swift
+++ b/LovelyCrane/View/WriteHistory/WriteHistoryView.swift
@@ -52,7 +52,7 @@ struct WriteHistoryView: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
             Text("97마리의 종이학을 발송했어요")
-                .foregroundColor(.white)
+                .foregroundColor(.primaryLabel)
             //텍스트랑 동일한 사이즈로 설정해줘야함.
         }.frame(height: 18)
             .padding(.vertical)
@@ -62,7 +62,7 @@ struct WriteHistoryView: View {
         HStack {
             Text("9127개")
                 .font(.system(size: 26))
-                .foregroundColor(.white)
+                .foregroundColor(.primaryLabel)
             Image(Assets.conceptCrane)
                 .resizable()
                 .aspectRatio(contentMode: .fit)

--- a/LovelyCrane/View/WritePage/EnlargedImageView.swift
+++ b/LovelyCrane/View/WritePage/EnlargedImageView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-// WriteView 또는 DetailView에서 이미지를 Tap 했을때 등장하는 이미지가 확대된 fullScreenView 입니다.
+// WriteView 또는 DetailView에서 이미지를 Tap 했을때 등장하는 이미지가 확대된 fullScreenCover 입니다.
 
 struct EnlargedImageView: View {
     @Environment(\.presentationMode) var presentationMode

--- a/LovelyCrane/View/WritePage/WriteView.swift
+++ b/LovelyCrane/View/WritePage/WriteView.swift
@@ -22,6 +22,7 @@ struct WriteView: View {
     @Binding var isShowingCurrentPage: Bool
     @State var showPhotoPickerActionSheet = false
     @State var showEnlargedImageView = false
+    @State var showDismissAlert = false
     var color: String
     @ObservedObject var keyboard = KeyboardObserver()
 
@@ -126,6 +127,14 @@ struct WriteView: View {
             .fullScreenCover(isPresented: $showEnlargedImageView) {
                 EnlargedImageView(image: $vm.image)
             }
+            .alert("쪽지 작성을 그만둘까요?", isPresented: $showDismissAlert) {
+                Button("확인", role: .cancel) {
+                    isShowingCurrentPage.toggle()
+              }
+                Button("취소", role: .destructive) {
+                  
+              }
+            }
         }
     }
     
@@ -133,7 +142,7 @@ struct WriteView: View {
         return HStack {
             Button(action: {
                 // full screen cover dismiss
-                isShowingCurrentPage.toggle()
+                showDismissAlert.toggle()
             }){
                 Image(systemName: "xmark")
                     .foregroundColor(Color.tertiaryLabel)

--- a/LovelyCrane/View/WritePage/WriteView.swift
+++ b/LovelyCrane/View/WritePage/WriteView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct WriteView: View {
     
-    let placeHolder = "상대방에게 전할 마음을 적어보세요 :)"
-    let letterLimit = 300 // 혹시 글자수 제한 바뀔 수 있어서 변수로 빼둠.
+    private let placeHolder = "상대방에게 전할 마음을 적어보세요 :)"
+    private let letterLimit = 300 // 혹시 글자수 제한 바뀔 수 있어서 변수로 빼둠.
     
     @StateObject var vm = WriteViewModel()
     
@@ -18,12 +18,13 @@ struct WriteView: View {
     
     let nowDate = getNowDate()
 
-    @State var isOverLetterLimit = false
+    @State private var isOverLetterLimit = false
     @Binding var isShowingCurrentPage: Bool
-    @State var showPhotoPickerActionSheet = false
-    @State var showEnlargedImageView = false
-    @State var showDismissAlert = false
+    @State private var showPhotoPickerActionSheet = false
+    @State private var showEnlargedImageView = false
+    @State private var showDismissAlert = false
     var color: String
+    
     @ObservedObject var keyboard = KeyboardObserver()
 
     
@@ -37,29 +38,29 @@ struct WriteView: View {
                     // 상단 헤더 (x버튼 + 쪽지쓰기 타이틀 + 저장 버튼)
                     showWriteViewHeader()
                         .padding(.bottom, 16)
+                    VStack(alignment: .leading, spacing: 28) { // ScrollView에 들어갈 Vstack (날짜 + 텍스트필드)
+                        Text(nowDate)
+                            .font(.system(size: 14, weight: .regular))
+                            .foregroundColor(Color.primaryLabel)
                         ScrollView {
-                            VStack(alignment: .leading, spacing: 28) { // ScrollView에 들어갈 Vstack (날짜 + 텍스트필드)
-                                Text(nowDate)
-                                    .font(.system(size: 14, weight: .regular))
-                                    .foregroundColor(Color.primaryLabel)
-                                ZStack(alignment: .topLeading) { // 플레이스홀더 + 텍스트필드
-                                    Text(placeHolder)
-                                        .foregroundColor(Color.secondaryLabel)
-                                        .opacity(vm.letterText.isEmpty ? 1 : 0)
-                                    letterLimitTextField(letterLimit: letterLimit)
-                                        .onReceive(vm.letterText.publisher.collect()) { collectionText in
+                            ZStack(alignment: .topLeading) { // 플레이스홀더 + 텍스트필드
+                                Text(placeHolder)
+                                    .foregroundColor(Color.secondaryLabel)
+                                    .opacity(vm.letterText.isEmpty ? 1 : 0)
+                                letterLimitTextField(letterLimit: letterLimit)
+                                        onReceive(vm.letterText.publisher.collect()) { collectionText in
                                             let trimmedText = String(collectionText.prefix(letterLimit))
                                             if vm.letterText != trimmedText {
                                                 isOverLetterLimit = vm.letterText.count > letterLimit ? true : false
                                                 vm.letterText = trimmedText
-                                            }
-                                            //isOverLetterLimit = vm.letterText.count > letterLimit
                                         }
+                                                //isOverLetterLimit = vm.letterText.count > letterLimit
+                                    }
                                 }
                             }
-                            .padding(.top, 30)
                         }
-                        .frame(maxHeight: isFocused && vm.letterText.count > 0 ? 270 : 1000)
+                        .padding(.top, 30)
+                        .frame(maxHeight: isFocused && vm.letterText.count > 0 ? UIScreen.getHeight(270) : 1000)
                     
                     Spacer()
                     
@@ -85,7 +86,7 @@ struct WriteView: View {
                         letterLimitLabel(letterLimit: letterLimit)
                         
                     }
-                    .offset(y:isFocused ? -keyboard.height+40 : 0)
+                    .offset(y:isFocused ? -UIScreen.getHeight(keyboard.height+40) : 0)
                     .animation(.easeOut(duration: 0.3), value: keyboard.height)
                 }
                 .padding(.top, 20)
@@ -207,7 +208,7 @@ struct WriteView: View {
     func letterLimitLabel(letterLimit: Int) -> some View {
         return Text("\($vm.letterText.wrappedValue.count)")
             .font(.system(size: 18.33, weight: .semibold))
-            .foregroundColor(isOverLetterLimit ? ($vm.letterText.wrappedValue.count < 300 ? .white : Color.defaultRed) : Color.primaryLabel)
+            .foregroundColor(isOverLetterLimit ? ($vm.letterText.wrappedValue.count < 300 ? Color.primaryLabel : Color.defaultRed) : Color.primaryLabel)
         + Text("/\(letterLimit)")
             .font(.system(size: 18.33, weight: .regular))
             .foregroundColor(Color.primaryLabel)

--- a/LovelyCrane/View/WritePage/WriteView.swift
+++ b/LovelyCrane/View/WritePage/WriteView.swift
@@ -58,7 +58,6 @@ struct WriteView: View {
                         }
                         .padding(.top, 30)
                     }
-                    // ScrollView의 Height Fix
                     
                     Spacer()
                     
@@ -84,7 +83,7 @@ struct WriteView: View {
                         letterLimitLabel(letterLimit: letterLimit)
                         
                     }
-                    .offset(y: isFocused ? -keyboard.height+100 : 0)
+                    .padding(.bottom, isFocused ? keyboard.height-40 : 0)
                     .padding(.bottom)
                     
                 }

--- a/LovelyCrane/View/WritePage/WriteView.swift
+++ b/LovelyCrane/View/WritePage/WriteView.swift
@@ -24,6 +24,7 @@ struct WriteView: View {
     @State var showEnlargedImageView = false
     var color: String
     @ObservedObject var keyboard = KeyboardObserver()
+
     
     var body: some View {
         GeometryReader { _ in // 키보드 등장시 화면이 avoid 하는 문제 방지.
@@ -40,10 +41,10 @@ struct WriteView: View {
                         VStack(alignment: .leading, spacing: 28) { // ScrollView에 들어갈 Vstack (날짜 + 텍스트필드)
                             Text(nowDate)
                                 .font(.system(size: 14, weight: .regular))
-                                .foregroundColor(Color.primary)
+                                .foregroundColor(Color.primaryLabel)
                             ZStack(alignment: .topLeading) { // 플레이스홀더 + 텍스트필드
                                 Text(placeHolder)
-                                    .foregroundColor(Color.secondary)
+                                    .foregroundColor(Color.secondaryLabel)
                                     .opacity(vm.letterText.isEmpty ? 1 : 0)
                                 letterLimitTextField(letterLimit: letterLimit)
                                     .onReceive(vm.letterText.publisher.collect()) { collectionText in
@@ -58,6 +59,7 @@ struct WriteView: View {
                         }
                         .padding(.top, 30)
                     }
+                    .frame(maxHeight: isFocused ? 270 : 582)
                     
                     Spacer()
                     
@@ -83,17 +85,18 @@ struct WriteView: View {
                         letterLimitLabel(letterLimit: letterLimit)
                         
                     }
-                    .padding(.bottom, isFocused ? keyboard.height-40 : 0)
-                    .padding(.bottom)
-                    
+                    .offset(y:isFocused ? -keyboard.height+40 : 0)
+                    .animation(.easeOut(duration: 0.3), value: keyboard.height)
                 }
                 .padding(.top, 20)
                 .padding(.horizontal, 28)
+                .padding(.bottom, 24)
             }
 
             .onAppear{
                 //keyboard Observer
                 self.keyboard.addObserver()
+                UIScrollView.appearance().bounces = false
             }
             .onDisappear{
                 self.keyboard.removeObserver()
@@ -135,12 +138,12 @@ struct WriteView: View {
             }){
                 Image(systemName: "xmark")
                     .foregroundColor(Color.tertiaryLabel)
-                    .font(.system(size: 25, weight: .regular))
+                    .frame(width: 20, height: 20)
             }
             
             Text("쪽지쓰기")
                 .font(.system(size: 20, weight: .regular))
-                .foregroundColor(Color.primary)
+                .foregroundColor(Color.primaryLabel)
                 .padding(.leading, 5.03)
             Spacer()
             Button(action: {
@@ -155,7 +158,7 @@ struct WriteView: View {
             }){
                 Text("저장")
                     .font(.system(size: 16.67, weight: .regular))
-                    .foregroundColor(Color.secondary)
+                    .foregroundColor(Color.secondaryLabel)
             }
         }
     }
@@ -196,10 +199,10 @@ struct WriteView: View {
     func letterLimitLabel(letterLimit: Int) -> some View {
         return Text("\($vm.letterText.wrappedValue.count)")
             .font(.system(size: 18.33, weight: .semibold))
-            .foregroundColor(isOverLetterLimit ? ($vm.letterText.wrappedValue.count < 300 ? .white : Color.defaultRed) : Color.primary)
+            .foregroundColor(isOverLetterLimit ? ($vm.letterText.wrappedValue.count < 300 ? .white : Color.defaultRed) : Color.primaryLabel)
         + Text("/\(letterLimit)")
             .font(.system(size: 18.33, weight: .regular))
-            .foregroundColor(Color.primary)
+            .foregroundColor(Color.primaryLabel)
     }
     
     /// 글자 제한이 있는 TextField를 추가
@@ -210,7 +213,7 @@ struct WriteView: View {
         TextField("", text: $vm.letterText, axis: .vertical)
                     .lineLimit(Int(letterLimit/20), reservesSpace: true)
                     .font(.system(size: 18.33, weight: .regular))
-                    .foregroundColor(Color.primary)
+                    .foregroundColor(Color.primaryLabel)
                     .multilineTextAlignment(.leading)
                     .focused($isFocused)
     }

--- a/LovelyCrane/View/WritePage/WriteView.swift
+++ b/LovelyCrane/View/WritePage/WriteView.swift
@@ -36,30 +36,29 @@ struct WriteView: View {
                     // 상단 헤더 (x버튼 + 쪽지쓰기 타이틀 + 저장 버튼)
                     showWriteViewHeader()
                         .padding(.bottom, 16)
-                    
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 28) { // ScrollView에 들어갈 Vstack (날짜 + 텍스트필드)
-                            Text(nowDate)
-                                .font(.system(size: 14, weight: .regular))
-                                .foregroundColor(Color.primaryLabel)
-                            ZStack(alignment: .topLeading) { // 플레이스홀더 + 텍스트필드
-                                Text(placeHolder)
-                                    .foregroundColor(Color.secondaryLabel)
-                                    .opacity(vm.letterText.isEmpty ? 1 : 0)
-                                letterLimitTextField(letterLimit: letterLimit)
-                                    .onReceive(vm.letterText.publisher.collect()) { collectionText in
-                                        let trimmedText = String(collectionText.prefix(letterLimit))
-                                        if vm.letterText != trimmedText {
-                                            isOverLetterLimit = vm.letterText.count > letterLimit ? true : false
-                                            vm.letterText = trimmedText
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 28) { // ScrollView에 들어갈 Vstack (날짜 + 텍스트필드)
+                                Text(nowDate)
+                                    .font(.system(size: 14, weight: .regular))
+                                    .foregroundColor(Color.primaryLabel)
+                                ZStack(alignment: .topLeading) { // 플레이스홀더 + 텍스트필드
+                                    Text(placeHolder)
+                                        .foregroundColor(Color.secondaryLabel)
+                                        .opacity(vm.letterText.isEmpty ? 1 : 0)
+                                    letterLimitTextField(letterLimit: letterLimit)
+                                        .onReceive(vm.letterText.publisher.collect()) { collectionText in
+                                            let trimmedText = String(collectionText.prefix(letterLimit))
+                                            if vm.letterText != trimmedText {
+                                                isOverLetterLimit = vm.letterText.count > letterLimit ? true : false
+                                                vm.letterText = trimmedText
+                                            }
+                                            //isOverLetterLimit = vm.letterText.count > letterLimit
                                         }
-                                        //isOverLetterLimit = vm.letterText.count > letterLimit
-                                    }
+                                }
                             }
+                            .padding(.top, 30)
                         }
-                        .padding(.top, 30)
-                    }
-                    .frame(maxHeight: isFocused ? 270 : 582)
+                        .frame(maxHeight: isFocused && vm.letterText.count > 0 ? 270 : 1000)
                     
                     Spacer()
                     


### PR DESCRIPTION
##  PR 😊

🥚 작업한 브랜치 : #32

## ✏️ 작업한 내용
- [ ] WriteView에서 키보드가 올라올때 이미지와 텍스트 자수 label이 따라 올라가는 motion에서 발생하는 버그 및 키보드 설정에 따라 올라가는 높이가 다른 문제를 fix 했습니다.
- [ ] WriteView에서 x 버튼을 눌렀을때, 뷰가 dismiss 되고, 메인뷰로 인입 되기 전 띄워질 확인 알럿을 구현했습니다.
- [ ] 뷰 파일들에서 잘못 작성된 컬러 변수를 수정했습니다. (ex) Color.secondary -> Color.secondaryLabel)


## 📷 스크린샷
<!— 작업한 뷰의 스크린샷을 올려주세요. —>
![image](https://github.com/DeveloperAcademy-POSTECH/MC3-Team6-MutekiNoIdoruPricura/assets/69354045/8bfce975-333e-4f98-b36e-c9b03dc8d472)

## 📮 관련 이슈
<!- 참고해야할 것이나 아직 해결 못해서 어려움을 겪고 있는경우 작성해주시면 됩니다 ->

