### PR TITLE
[Feat] 닉네임 수정 알럿 추가 및 담당 뷰 커스텀 폰트 적용

### DIFF
--- a/LovelyCrane.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LovelyCrane.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -61,6 +61,8 @@
       "state" : {
         "revision" : "58d03d22beae762eaddbd30cb5a61af90d4b309f",
         "version" : "7.11.3"
+        "revision" : "4446686bc3714d49ce043d0f68318f42ed718cb6",
+        "version" : "7.11.4"
       }
     },
     {
@@ -115,6 +117,8 @@
       "state" : {
         "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
         "version" : "2.2.0"
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
       }
     },
     {
@@ -124,6 +128,8 @@
       "state" : {
         "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
         "version" : "1.22.0"
+        "revision" : "ce20dc083ee485524b802669890291c0d8090170",
+        "version" : "1.22.1"
       }
     }
   ],

--- a/LovelyCrane/Common/Components/CustomAlerts/FadeAlertView.swift
+++ b/LovelyCrane/Common/Components/CustomAlerts/FadeAlertView.swift
@@ -12,7 +12,6 @@ struct FadeAlertView: View {
     @Binding var showAlert: Bool
     let alertMessage: FadeAlertMessage = .nickNameSaved
 
-    
     var body: some View {
         VStack {
             if showAlert {
@@ -33,12 +32,13 @@ struct FadeAlertView: View {
             }
         }
         .onAppear(){
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                self.showAlert = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                withAnimation(.easeInOut(duration: 1.0)) {
+                    self.showAlert = false
+                }
             }
         }
     }
-    
 }
 
 enum FadeAlertMessage: String {

--- a/LovelyCrane/View/Login/AuthenticationView.swift
+++ b/LovelyCrane/View/Login/AuthenticationView.swift
@@ -48,11 +48,11 @@ extension AuthenticationView {
             
             VStack(alignment: .center, spacing: 8) {
                 Text("사랑의 종이학")
-                    .font(.title)
+                    .font(.title2font())
                 Text("사랑하는 마음을 차곡차곡 모아")
-                    .font(.callout)
+                    .font(.footnotefont())
                 Text("상대방에게 선물해요")
-                    .font(.callout)
+                    .font(.footnotefont())
             }
             .foregroundColor(.white)
         }

--- a/LovelyCrane/View/Login/NicknameView.swift
+++ b/LovelyCrane/View/Login/NicknameView.swift
@@ -26,7 +26,7 @@ struct NicknameView: View {
                 VStack(alignment: .center, spacing: 40) {
                     makeHeaderImageText()
                     
-                    VStack {
+                    VStack(spacing: 16) {
                         makeNicknameTextField()
                         makeNicknameCountCaution()
                     }
@@ -46,18 +46,19 @@ struct NicknameView: View {
 extension NicknameView {
 
     private func makeHeaderImageText() -> some View {
-        VStack(spacing: 5) {
+        VStack(spacing: 16) {
             Image(Assets.nicknameViewImage)
                 .resizable()
                 .frame(width: UIScreen.getWidth(124), height: UIScreen.getHeight(48))
 
             Text("사용하실 닉네임을 알려주세요")
+                .font(.headlinefont())
                 .foregroundColor(.primaryLabel)
         }
     }
     
     private func makeNicknameTextField() -> some View {
-        TextField("닉네임을 입력해주세요", text: $viewModel.nickname)
+        TextField("", text: $viewModel.nickname)
             .focused($nicknameInFocus)
             .foregroundColor(.primaryLabel)
             .multilineTextAlignment(TextAlignment.center)
@@ -68,6 +69,7 @@ extension NicknameView {
                     Color.textFieldGray
                     if viewModel.nickname.isEmpty {
                         Text("닉네임을 입력해주세요")
+                            .font(.bodyfont())
                             .foregroundColor(Color.tertiaryLabel)
                     }
                 }
@@ -82,6 +84,7 @@ extension NicknameView {
                 .frame(width: UIScreen.getWidth(14), height: UIScreen.getHeight(14))
                 .opacity(viewModel.nickname.count > 8 ? 1 : 0)
             Text("닉네임은 8자 이하로 입력해주세요")
+                .font(.footnotefont())
                 .foregroundColor(viewModel.nickname.count > 8 ? Color.defaultYellow : Color.tertiaryLabel)
         }
     }
@@ -99,6 +102,7 @@ extension NicknameView {
             }
         }, label: {
             Text("완료")
+                .font(.bodyfont())
                 .foregroundColor(viewModel.nickname.isEmpty || viewModel.nickname.count > 8 ? .quarternaryLabel : .gray1)
                 .frame(height: 55)
                 .frame(maxWidth: .infinity)

--- a/LovelyCrane/View/ReceiveHistory/NoReceivedView.swift
+++ b/LovelyCrane/View/ReceiveHistory/NoReceivedView.swift
@@ -14,7 +14,7 @@ struct NoReceivedView: View {
         ZStack {
             Color(.backGround).ignoresSafeArea()
             
-            VStack {
+            VStack(spacing: 20) {
                 Image(Assets.noReceivedViewImage)
                     .resizable()
                     .frame(width: UIScreen.getWidth(206), height: UIScreen.getHeight(158))
@@ -23,6 +23,7 @@ struct NoReceivedView: View {
                     Text("아직 연인에게")
                     Text("선물받은 쪽지가 없어요!")
                 }
+                .font(.headlinefont())
                 .foregroundColor(.white)
                 
                 Button {
@@ -30,9 +31,9 @@ struct NoReceivedView: View {
                     
                 } label: {
                     Text("메인으로 가기")
+                        .font(.headlinefont())
                         .foregroundColor(.lightPink)
                 }
-                .padding(.top, 20)
             }
         }
         .navigationBarBackButtonHidden(true)
@@ -40,6 +41,7 @@ struct NoReceivedView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 Image(systemName: "chevron.left")
                     .foregroundColor(.gray)
+                    .padding(.trailing, 15)
                     .onTapGesture {
                         dismiss()
                     }

--- a/LovelyCrane/View/ReceiveHistory/ReceivedHistoryCell.swift
+++ b/LovelyCrane/View/ReceiveHistory/ReceivedHistoryCell.swift
@@ -20,7 +20,7 @@ struct ReceivedHistoryCell: View {
                 VStack(alignment: .leading) {
                     Text(Date.formatDate(letter.date))
                         .foregroundColor(.secondaryLabel)
-                        .font(.caption)
+                        .font(.caption1font())
                     
                     Spacer()
                     
@@ -28,7 +28,7 @@ struct ReceivedHistoryCell: View {
                         .foregroundColor(.white)
                         .lineLimit(2)
                         .padding(.trailing, 5)
-                        .font(.caption)
+                        .font(.footnotefont())
                         .padding(.bottom)
                 }
                 .padding(.leading, 5)

--- a/LovelyCrane/View/ReceiveHistory/ReceivedHistoryView.swift
+++ b/LovelyCrane/View/ReceiveHistory/ReceivedHistoryView.swift
@@ -49,16 +49,17 @@ extension ReceivedHistoryView {
     
     private func makeHeaderImageText() -> some View {
         HStack(alignment: .center) {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 16) {
                 Text("받은 쪽지")
+                    .font(.bodyfont())
                     .foregroundColor(.gray)
                 
                 HStack(alignment: .firstTextBaseline) {
                     Text("\(receivedLettersCount)")
-                        .font(.largeTitle)
+                        .font(.title1font())
                         .foregroundColor(.lightPink)
                     Text("마리")
-                        .font(.title2)
+                        .font(.title3font())
                         .foregroundColor(.white)
                 }
             }
@@ -81,11 +82,11 @@ extension ReceivedHistoryView {
                             .frame(width: UIScreen.getWidth(9.94), height: UIScreen.getHeight(14.21))
                         
                         Text("\(receivedLettersGroup.count)마리의 종이학을 선물받았어요 :)")
-                            .font(.caption)
+                            .font(.caption1font())
                             .foregroundColor(.white)
                         
                         Text("-" + Date.formatDate(date))
-                            .font(.caption)
+                            .font(.caption2font())
                             .foregroundColor(Color.tertiaryLabel)
                     }
                     .padding(.leading, 20)

--- a/LovelyCrane/View/Setting/SettingView.swift
+++ b/LovelyCrane/View/Setting/SettingView.swift
@@ -13,74 +13,90 @@ struct SettingView: View {
     @StateObject private var vm = SettingViewModel()
     @EnvironmentObject var viewRouter : ViewRouter
     
+    @State var savedNickname = false
+
     init() {
-      let navBarAppearance = UINavigationBar.appearance()
-      navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
-      navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        let navBarAppearance = UINavigationBar.appearance()
+        if let uiFont = convertToUIFont(.headlinefont(), size: 20) {
+            navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white, .font: uiFont]
+            navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white, .font: uiFont]
+        }
     }
     
     var body: some View {
+        ZStack(alignment: .center) {
             ZStack(alignment: .topLeading) {
-                Color(.backGround).ignoresSafeArea()
-                HStack {
-                    VStack(alignment: .leading, spacing: 20) {
-                        NavigationLink {
-                            UpdateNicknameView()
-                        } label: {
-                            makeCell(name: "닉네임 수정")
-                        }
+                    Color(.backGround).ignoresSafeArea()
+                    HStack {
+                        VStack(alignment: .leading, spacing: 20) {
+                            NavigationLink {
+                                UpdateNicknameView(savedNickname: $savedNickname)
+                            } label: {
+                                makeCell(name: "닉네임 수정")
+                            }
 
-                        makeCell(name: "로그아웃")
-                            .onTapGesture {
-                                Task {
-                                    do {
-                                        try vm.logout()
-                                        viewRouter.currentPage = .launchsScreenView
-                                        
-                                    } catch {
-                                        print(error.localizedDescription)
+                            makeCell(name: "로그아웃")
+                                .onTapGesture {
+                                    Task {
+                                        do {
+                                            try vm.logout()
+                                            viewRouter.currentPage = .launchsScreenView
+                                            
+                                        } catch {
+                                            print(error.localizedDescription)
+                                        }
                                     }
                                 }
-                            }
-                        makeCell(name: "회원탈퇴")
-                            .onTapGesture {
-                                Task {
-                                    do {
-                                        try await vm.deleteUser()
-                                        try vm.logout()
-                                        viewRouter.currentPage = .authenticationView
-                                    } catch {
-                                        print(error.localizedDescription)
+                            makeCell(name: "회원탈퇴")
+                                .onTapGesture {
+                                    Task {
+                                        do {
+                                            try await vm.deleteUser()
+                                            try vm.logout()
+                                            viewRouter.currentPage = .authenticationView
+                                        } catch {
+                                            print(error.localizedDescription)
+                                        }
                                     }
                                 }
-                            }
-                        makeCell(name: "만든 사람들")
-                    }
-                    Spacer()
-                }
-                .padding(.horizontal, 16)
-            }
-            .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Image(systemName: "chevron.left")
-                        .foregroundColor(Color.tertiaryLabel)
-                        .padding(.trailing, 15)
-                        .onTapGesture {
-                            dismiss()
+                            makeCell(name: "만든 사람들")
                         }
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
                 }
-            }
-            .navigationTitle("설정")
+                .navigationBarBackButtonHidden(true)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(Color.tertiaryLabel)
+                            .padding(.trailing, 15)
+                            .onTapGesture {
+                                dismiss()
+                            }
+                    }
+                }
+                .navigationTitle("설정")
             .navigationBarTitleDisplayMode(.inline)
+            
+            FadeAlertView(showAlert: $savedNickname)
+        }
     }
 }
 
 extension SettingView {
     
+    private func convertToUIFont(_ font: Font, size: CGFloat) -> UIFont? {
+        if let customFont = UIFont(name: "omyu pretty", size: size) {
+            return customFont
+        }
+        return nil
+    }
+    
     private func makeCell(name: String) -> some View {
         VStack(alignment: .leading) {
             Text(name)
+                .font(.headlinefont())
                 .foregroundColor(.white)
                 .padding()
         }

--- a/LovelyCrane/View/Setting/UpdateNicknameView.swift
+++ b/LovelyCrane/View/Setting/UpdateNicknameView.swift
@@ -14,11 +14,16 @@ struct UpdateNicknameView: View {
     @FocusState private var nicknameInFocus: Bool
 
     @Environment(\.dismiss) var dismiss
+    @Binding var savedNickname: Bool
     
-    init() {
-      let navBarAppearance = UINavigationBar.appearance()
-      navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white]
-      navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+    init(savedNickname: Binding<Bool>) {
+        _savedNickname = savedNickname
+        
+        let navBarAppearance = UINavigationBar.appearance()
+        if let uiFont = convertToUIFont(.headlinefont(), size: 20) {
+            navBarAppearance.largeTitleTextAttributes = [.foregroundColor: UIColor.white, .font: uiFont]
+            navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white, .font: uiFont]
+        }
     }
     
     var body: some View {
@@ -72,12 +77,14 @@ extension UpdateNicknameView {
                 .frame(width: UIScreen.getWidth(124), height: UIScreen.getHeight(48))
 
             Text("사용하실 닉네임을 알려주세요")
+                .font(.headlinefont())
                 .foregroundColor(.primaryLabel)
         }
     }
     
     private func makeNicknameTextField() -> some View {
         TextField("", text: $viewModel.nickname)
+            .font(.bodyfont())
             .focused($nicknameInFocus)
             .foregroundColor(.primaryLabel)
             .multilineTextAlignment(TextAlignment.center)
@@ -88,6 +95,7 @@ extension UpdateNicknameView {
                     Color.textFieldGray
                     if viewModel.nickname.count == 0 {
                         Text("닉네임을 입력해주세요.")
+                            .font(.bodyfont())
                             .foregroundColor(Color.tertiaryLabel)
                     }
                 }
@@ -102,6 +110,7 @@ extension UpdateNicknameView {
                 .frame(width: UIScreen.getWidth(14), height: UIScreen.getHeight(14))
                 .opacity(viewModel.nickname.count > 8 ? 1 : 0)
             Text("닉네임은 8자 이하로 입력해주세요")
+                .font(.footnotefont())
                 .foregroundColor(viewModel.nickname.count > 8 ? Color.defaultYellow : Color.tertiaryLabel)
         }
     }
@@ -112,6 +121,11 @@ extension UpdateNicknameView {
                 do {
                     try await viewModel.updateNickName(nickName: viewModel.nickname)
                     dismiss()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        withAnimation(.easeOut(duration: 0.5)) {
+                            savedNickname = true
+                        }
+                    }
                 }
                 catch{
                     print("error")
@@ -119,6 +133,7 @@ extension UpdateNicknameView {
             }
         }, label: {
             Text("저장하기")
+                .font(.bodyfont())
                 .foregroundColor(viewModel.isValidNickName() ? .gray1 : .quarternaryLabel)
                 .frame(height: 55)
                 .frame(maxWidth: .infinity)
@@ -130,10 +145,17 @@ extension UpdateNicknameView {
         .disabled(viewModel.nickname.isEmpty || viewModel.nickname.count > 8)
         .padding(.bottom, 25)
     }
+    
+    private func convertToUIFont(_ font: Font, size: CGFloat) -> UIFont? {
+        if let customFont = UIFont(name: "omyu pretty", size: size) {
+            return customFont
+        }
+        return nil
+    }
 }
 
 struct UpdateNicknameView_Previews: PreviewProvider {
     static var previews: some View {
-        UpdateNicknameView()
+        UpdateNicknameView(savedNickname: .constant(false))
     }
 }

--- a/LovelyCrane/View/WriteHistory/NoWriteView.swift
+++ b/LovelyCrane/View/WriteHistory/NoWriteView.swift
@@ -16,7 +16,7 @@ struct NoWriteView: View {
         ZStack {
             Color(.backGround).ignoresSafeArea()
             
-            VStack {
+            VStack(spacing: 20) {
                 Image(Assets.noWriteCrane)
                     .resizable()
                     .frame(width: UIScreen.getWidth(206), height: UIScreen.getHeight(158))
@@ -25,6 +25,7 @@ struct NoWriteView: View {
                     Text("아직 연인에게")
                     Text("쓴 쪽지가 없어요!")
                 }
+                .font(.headlinefont())
                 .foregroundColor(.white)
                 
                 Button {
@@ -32,9 +33,9 @@ struct NoWriteView: View {
                     writeLetterButtonTapped.toggle()
                 } label: {
                     Text("쪽지 작성하기")
+                        .font(.headlinefont())
                         .foregroundColor(.lightPink)
                 }
-                .padding(.top, 20)
             }
         }
         .navigationBarBackButtonHidden(true)
@@ -42,6 +43,7 @@ struct NoWriteView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 Image(systemName: "chevron.left")
                     .foregroundColor(.gray)
+                    .padding(.trailing, 15)
                     .onTapGesture {
                         dismiss()
                     }

--- a/LovelyCrane/View/WriteHistory/WriteHistoryCell.swift
+++ b/LovelyCrane/View/WriteHistory/WriteHistoryCell.swift
@@ -20,7 +20,7 @@ struct WriteHistoryCell: View {
                 VStack(alignment: .leading) {
                     Text(Date.formatDate(letter.date))
                         .foregroundColor(.secondaryLabel)
-                        .font(.caption)
+                        .font(.caption1font())
                     
                     Spacer()
                     
@@ -28,7 +28,7 @@ struct WriteHistoryCell: View {
                         .foregroundColor(.white)
                         .lineLimit(2)
                         .padding(.trailing, 5)
-                        .font(.caption)
+                        .font(.footnotefont())
                         .padding(.bottom)
                 }
                 .padding(.leading, 5)
@@ -74,7 +74,7 @@ extension WriteHistoryCell {
 struct WriteHistoryCell_Previews: PreviewProvider {
     
     static let testLetter1 = LetterModel(id: "s", image: "", date: .now, text: "dhdhdh", isByme: true, isSent: false, isRead: false)
-    static let testLetter2 = LetterModel(id: "s", image: "", date: .now, text: "dhdhdh", isByme: true, isSent: false, isRead: false)
+    static let testLetter2 = LetterModel(id: "s", image: "", date: .now, text: "adsfadsfasdfadsgsdgdsgadsgasdgadsgadsgasdgadsgasdgadsgsadgadsg", isByme: true, isSent: false, isRead: false)
     
     
     static var previews: some View {

--- a/LovelyCrane/View/WriteHistory/WriteHistoryView.swift
+++ b/LovelyCrane/View/WriteHistory/WriteHistoryView.swift
@@ -53,16 +53,17 @@ extension WriteHistoryView {
     
     private func makeHeaderImageText() -> some View {
         HStack(alignment: .center) {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 16) {
                 Text("나의 쪽지")
+                    .font(.bodyfont())
                     .foregroundColor(.gray)
                 
                 HStack(alignment: .firstTextBaseline) {
                     Text("\(letterCount)")
-                        .font(.largeTitle)
+                        .font(.title1font())
                         .foregroundColor(.lightPink)
                     Text("마리")
-                        .font(.title2)
+                        .font(.title3font())
                         .foregroundColor(.white)
                 }
             }
@@ -100,11 +101,11 @@ extension WriteHistoryView {
                             .frame(width: UIScreen.getWidth(12.75), height: UIScreen.getHeight(11.46))
 
                         Text("\(sentLettersGroup.count)마리의 종이학을 발송했어요 :)")
-                            .font(.caption)
+                            .font(.caption1font())
                             .foregroundColor(.white)
                         
                         Text("-" + Date.formatDate(date))
-                            .font(.caption)
+                            .font(.caption2font())
                             .foregroundColor(Color.tertiaryLabel)
                     }
                     .padding(.leading, 20)

--- a/LovelyCrane/ViewModel/Setting/SettingViewModel.swift
+++ b/LovelyCrane/ViewModel/Setting/SettingViewModel.swift
@@ -30,5 +30,6 @@ final class SettingViewModel: ObservableObject {
         try await AuthenticationManager.shared.reauthenticationUser()
         UserManager.shared.deleteUserDocument()
         try await AuthenticationManager.shared.deleteUser()
+        UserDefaults.standard.set("", forKey: "nickname")
     }
 }


### PR DESCRIPTION
##  PR 😊

🥚 작업한 브랜치 : #55 

## ✏️ 작업한 내용

디자인에 맞춰 커스텀 폰트를 적용 및 레이아웃을 수정합니다.
닉네임 수정 뷰에 알럿을 추가합니다.

- [x] AuthenticationView
- [x] NicknameView
- [x] NoWriteView
- [x] WriteHistoryCell
- [x] WriteHistoryView
- [x] NoReceivedView
- [x] ReceivedHistoryCell
- [x] ReceivedHistoryView
- [x] SettingView
네비게이션 타이틀 수정
- [x] UpdateNicknameView
네비게이션 타이틀 수정
알럿 추가
- [x] 자연스러운 알럿 등장 및 사라짐을 위해 애니메이션이 추가되었습니다. (FadeAlertView)

## 📷 스크린샷

## 📮 관련 이슈
