### PR TITLE
#64/data bug fix

### DIFF
--- a/LovelyCrane.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LovelyCrane.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "4446686bc3714d49ce043d0f68318f42ed718cb6",
-        "version" : "7.11.4"
+        "revision" : "58d03d22beae762eaddbd30cb5a61af90d4b309f",
+        "version" : "7.11.3"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
-        "version" : "2.3.1"
+        "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
+        "version" : "2.2.0"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ce20dc083ee485524b802669890291c0d8090170",
-        "version" : "1.22.1"
+        "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
+        "version" : "1.22.0"
       }
     }
   ],

--- a/LovelyCrane/Common/Components/CustomAlerts/PresentAlertView.swift
+++ b/LovelyCrane/Common/Components/CustomAlerts/PresentAlertView.swift
@@ -90,6 +90,9 @@ struct PresentAlertView: View {
                                 self.showTouchCraneAlert.toggle()
                             case .presentCrane:
                                 NotificationCenter.default.post(name: Notification.Name("successPresent"), object: nil)
+                                Task {
+                                    try await UserManager.shared.sendletterLists()
+                                }
                                 self.showAlert.toggle()
                             case .fullBottle:
                                 self.showAlert.toggle()

--- a/LovelyCrane/ContentView.swift
+++ b/LovelyCrane/ContentView.swift
@@ -46,7 +46,6 @@ extension ContentView {
                 try await UserManager.shared.getmyUserData()
                 await checkDocumentNickName()
             }
-
         } else {
             viewRouter.currentPage = .authenticationView
         }

--- a/LovelyCrane/Network/Firebase/UserManager.swift
+++ b/LovelyCrane/Network/Firebase/UserManager.swift
@@ -174,7 +174,7 @@ final class UserManager {
             guard let data = documents.data() else {return}
             guard let receivecount = data["receive_count"] as? Int else {return}
             if self.partnerNickName != UserInfo.shared.partnerNickName {
-                NotificationCenter.default.post(name: Notification.Name("successPresent"), object: nil)
+                NotificationCenter.default.post(name: Notification.Name("connectPartner"), object: nil)
             } else if receivecount != UserInfo.shared.receiveLetterCount {
                 NotificationCenter.default.post(name: Notification.Name("open"), object: nil)
             }

--- a/LovelyCrane/Network/Firebase/UserManager.swift
+++ b/LovelyCrane/Network/Firebase/UserManager.swift
@@ -73,14 +73,17 @@ final class UserManager {
         let snapshot = try await getUserDocument().getDocument()
         let partnerField = FieldNames.partner_id.rawValue
         guard let data = snapshot.data() else {return}
-        guard let partnertoken = data[partnerField] as? String else {return}
-        let partnerDocument = try await userCollection.document(partnertoken).getDocument()
+        if let partnerToken = data[partnerField] as? String {
+            let partnerDocument = try await userCollection.document(partnerToken).getDocument()
+            UserInfo.shared.partnerNickName = partnerDocument[FieldNames.nickname.rawValue] as! String
+        }
+
         DispatchQueue.main.async {
             UserInfo.shared.nickName = data["nickname"] as! String
             UserInfo.shared.sendLetterCount = data["send_count"] as! Int
             UserInfo.shared.notSendLetterCount = data["notsend_count"] as! Int
             UserInfo.shared.receiveLetterCount = data["receive_count"] as! Int
-            UserInfo.shared.partnerNickName = partnerDocument[FieldNames.nickname.rawValue] as! String
+
         }
     }
 

--- a/LovelyCrane/View/ConnectPage/CouplingView.swift
+++ b/LovelyCrane/View/ConnectPage/CouplingView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 struct CouplingView: View {
     private let mycode = UserManager.shared.currentUserUID
     @State private var clickPasteBtn = false
-    @State var isOpen = true
+    @Binding var isOpen : Bool
     var body: some View {
         NavigationView {
             VStack{

--- a/LovelyCrane/View/Main/MainView.swift
+++ b/LovelyCrane/View/Main/MainView.swift
@@ -24,6 +24,7 @@ struct MainView: View {
     @State private var isCoupleingTapped = false
     @State private var showPresentAlert = false
     @State private var isPresented = false
+    @State private var isConnectFirst = false
     @State private var presentStrings: [String] = ["선", "물", "하", "기"]
     @State private var selection = 0
     @EnvironmentObject var viewRouter : ViewRouter
@@ -33,6 +34,7 @@ struct MainView: View {
     let updateCenter = NotificationCenter.default.publisher(for: Notification.Name("update"))
     let successPresentCenter = NotificationCenter.default.publisher(for: Notification.Name("successPresent"))
     let openCenter = NotificationCenter.default.publisher(for: Notification.Name("open"))
+    let partnerConnectCenter = NotificationCenter.default.publisher(for: Notification.Name("connectPartner"))
     
     var body: some View {
         ZStack {
@@ -68,6 +70,9 @@ struct MainView: View {
             }
             .onReceive(successPresentCenter) { _ in
                 isPresented.toggle()
+            }
+            .onReceive(partnerConnectCenter) { _ in
+                isConnectFirst.toggle()
             }
             if showPresentAlert {
                 PresentAlertView(alertType: .presentCrane, showAlert: $showPresentAlert)
@@ -145,7 +150,7 @@ struct MainView: View {
                                 }
                             }
                             .fullScreenCover(isPresented: $isCoupleingTapped) {
-                                CouplingView()
+                                CouplingView(isOpen: $isCoupleingTapped)
                             }
                         }
                         .offset(x: UIScreen.getWidth(-7))
@@ -256,7 +261,7 @@ struct MainView: View {
                             isCoupleingTapped.toggle()
                         }
                         .fullScreenCover(isPresented: $isCoupleingTapped) {
-                            CouplingView()
+                            CouplingView(isOpen: $isCoupleingTapped)
                         }
                 }
             }

--- a/LovelyCrane/View/Main/MainView.swift
+++ b/LovelyCrane/View/Main/MainView.swift
@@ -78,6 +78,9 @@ struct MainView: View {
                     .transition(.opacity.animation(.easeIn))
             }
         }
+        .onAppear {
+            UserManager.shared.listenConnectPartner()
+        }
     }
 
     //MARK: - Views


### PR DESCRIPTION
##  PR 😊

🥚 작업한 브랜치 : #64 

## ✏️ 작업한 내용
- [x] mainView에서 onApear되면 listen메소드를 계속 보고 있다가 특정한 이벤트가 도착하면 notif를 쏴준다. 
`if self.partnerNickName != UserInfo.shared.partnerNickName {
                NotificationCenter.default.post(name: Notification.Name("connectPartner"), object: nil)
            } else if receivecount != UserInfo.shared.receiveLetterCount {
                NotificationCenter.default.post(name: Notification.Name("open"), object: nil)
            }`
파트너 닉네임이 추가되면 connetPartner라는 노티를 보내주고 메인에서 이걸 확인하면 isConncetFirst가 토글되면서 AlertModal이 뜬다
마찬가지로 받은 선물이 추가되면 open이라는 노티피케이션을 보내주고 메인에서 확인후 선물받기 Alert뜨도록
- [x] 파트너가 처음에 없을때 get에러 버그 픽스


## 📷 스크린샷
<!— 작업한 뷰의 스크린샷을 올려주세요. —>
<!— 이미지 크기를 40%로 줄여서 올려주세요.
|<img src = "url" width = 40%>|<img src = "url2" width = 40%>|
|:--:|:--:|
## 📮 관련 이슈
<!- 참고해야할 것이나 아직 해결 못해서 어려움을 겪고 있는경우 작성해주시면 됩니다 ->
- Ex) 파베 연결실패
